### PR TITLE
Eli 2

### DIFF
--- a/R/pairedPlots.R
+++ b/R/pairedPlots.R
@@ -84,9 +84,8 @@ pairedPlot <- function(glmmResult,
                        graphics="base",
                        addModel=TRUE,
                        modelSize=3,
-                       modelColour="black",
                        modelLineSize=1,
-                       modelLineColour="black",
+                       modelColour="black",
                        addBox=FALSE,
                        addViolins=TRUE,
                        violinWidth=0.5,
@@ -221,13 +220,13 @@ pairedPlot <- function(glmmResult,
       for(i in unique(df_mean$group)){
         lines(df_mean$x1Factors[df_mean$group == i],
               df_mean$y[df_mean$group == i],
-              lwd=modelSize+1, col=modelLineColour[i])
+              lwd=modelSize+1, col=modelColour[i])
       }
       segments(df_mean$x1Factors, df_mean$upper,
                df_mean$x1Factors, df_mean$lower,
-               lwd=modelSize+1, col=modelColour)
-      points(df_mean$x1Factors, df_mean$y, type = "p", bg=modelColour,
-             col=modelColour, pch=21, cex=modelSize)
+               lwd=modelSize+1, col=rep(modelColour, each=length(unique(df_mean$group))))
+      points(df_mean$x1Factors, df_mean$y, type = "p", bg=rep(modelColour, each=length(unique(df_mean$group))),
+             col=rep(modelColour, each=length(unique(df_mean$group))), pch=21, cex=modelSize)
     }
 
     if(addBox){

--- a/R/pairedPlots.R
+++ b/R/pairedPlots.R
@@ -78,6 +78,7 @@ pairedPlot <- function(glmmResult,
                        lineColour='grey60',
                        markerSize=2,
                        fontSize=NULL,
+                       stat_fontSize=NULL,
                        alpha=0.7,
                        x2Offset=6,
                        pairedOnly=TRUE,
@@ -244,7 +245,7 @@ pairedPlot <- function(glmmResult,
       paste("P"[.(x1Label)]*"=", .(pval[1]),
             ", P"[.(x2Label)]*"=", .(pval[2]),
             ", P"[paste(.(x1Label), ":", .(x2Label))]*"=",
-            .(pval[3]))), cex=fontSize,
+            .(pval[3]))), cex=stat_fontSize,
       side=3, adj=0)
 
 

--- a/R/pairedPlots.R
+++ b/R/pairedPlots.R
@@ -206,7 +206,7 @@ pairedPlot <- function(glmmResult,
     plot(as.numeric(df_long$x1Factors), df_long$geneExp,
          type='p', bty='l', las=2,
          xaxt='n', cex.axis=fontSize, cex.lab=fontSize,
-         pch=shapes[df_long$x2], bg=colours[df_long$x2],
+         pch=shapes[df_long$x2], bg=colours[df_long$x2], col = colours[df_long$x2],
          cex=markerSize, xlab=xTitle, ylab=yTitle,
          log=log,
          ...,
@@ -214,20 +214,20 @@ pairedPlot <- function(glmmResult,
            for (i in unique(df_long$id)) {
              lines(df_long$x1Factors[df_long$id==i],
                    df_long$geneExp[df_long$id==i],
-                   col=lineColour)}
+                   col=lineColour[df_long[which(df_long$id == i), x2Label]]))}
          })
 
     if(addModel){
       for(i in unique(df_mean$group)){
         lines(df_mean$x1Factors[df_mean$group == i],
               df_mean$y[df_mean$group == i],
-              lwd=modelSize+1, col=modelLineColour)
+              lwd=modelSize+1, col=modelLineColour[i])
       }
       segments(df_mean$x1Factors, df_mean$upper,
                df_mean$x1Factors, df_mean$lower,
-               lwd=modelSize+1, col=modelLineColour)
+               lwd=modelSize+1, col=modelColour)
       points(df_mean$x1Factors, df_mean$y, type = "p", bg=modelColour,
-             col=modelLineColour, pch=21, cex=modelSize)
+             col=modelColour, pch=21, cex=modelSize)
     }
 
     if(addBox){


### PR DESCRIPTION
**1. Adjusting bug in color with basic graphics - Option 2
2. Add parameter to adjust statistics font size**

1. If one wants to plot the model I guess should use the same color for point, segment and line, so there's no need to use both `modelColour `and `modelLineColour `.
If so, you can simply use only one modelColour parameter (and avoid using modelLineColour).
where `modelColour `needs to be a named vector, such as: 
`modelLineColour  = c("non responder" ='mediumblue', "responder" = 'firebrick')`

**NOT TESTED FOR GGPLOT**

_**old plot:**_ 
![OLD](https://user-images.githubusercontent.com/70027703/114583877-f3314380-9c79-11eb-92c0-0643ce22cf39.PNG)

**_new plot:_**
![new](https://user-images.githubusercontent.com/70027703/114584105-37bcdf00-9c7a-11eb-83e3-750bbd86754d.PNG)
