### PR TITLE
Adjust ylim when plotting the model

### DIFF
--- a/R/pairedPlots.R
+++ b/R/pairedPlots.R
@@ -215,8 +215,10 @@ pairedPlot <- function(glmmResult,
   if(graphics == "base"){
     if(logTransform) log <- "y" else log <- ""
     if(is.null(xTitle)) xTitle <- NA
+    if(addModel) my.ylim = c(min(df_mean$lower), max(df_mean$upper))
+    else my.ylim = NULL
     plot(as.numeric(df_long$x1Factors), df_long$geneExp,
-         type='p', bty='l', las=2,
+         ylim = my.ylim, type='p', bty='l', las=2,
          xaxt='n', cex.axis=fontSize, cex.lab=fontSize,
          pch=shapes[df_long$x2], bg=colours[df_long$x2],
          cex=markerSize, xlab=xTitle, ylab=yTitle,


### PR DESCRIPTION
When adding the model to the plot `ylim` must be corrected to let the confidence interval be drawn, otherwise it might be partially cut out. 