### PR TITLE
Specify design matrix

### DIFF
--- a/R/glmmSeq.R
+++ b/R/glmmSeq.R
@@ -346,14 +346,14 @@ glmerApply <- function(geneList,
                          c(paste0("Chisq_", rownames(wald)),
                            paste0("P_", rownames(wald))))
     newY <- predict(fit, newdata = modelData, re.form = NA)
-    a <- designMatrix %*% vcov(fit)
+    a <- designMatrix %*% suppressWarnings(vcov(fit))
     b <- as.matrix(a %*% t(designMatrix))
     predVar <- diag(b)
     newSE <- sqrt(predVar)
     newLCI <- exp(newY - newSE * 1.96)
     newUCI <- exp(newY + newSE * 1.96)
     predictdf <- c(exp(newY), newLCI, newUCI)
-    singular <- as.numeric(lme4::isSingular(fit))
+    singular <- suppressWarnings(is.numeric(lme4::isSingular(fit)))
     conv <- length(slot(fit, "optinfo")$conv$lme4$messages)
     rm(fit, data)
     return(list(stats = c(stats, fixedEffects, waldtest),

--- a/R/glmmSeq.R
+++ b/R/glmmSeq.R
@@ -324,7 +324,7 @@ glmerApply <- function(geneList,
                        offset,
                        ...) {
   data[, "count"] <- as.numeric(geneList$y)
-  fit <- try(suppressMessages(
+  fit <- try(suppressWarnings(
     lme4::glmer(fullFormula, data = data, control = control, offset = offset,
                 family = MASS::negative.binomial(theta = 
                                                    1/geneList$dispersion)),

--- a/R/glmmSeq.R
+++ b/R/glmmSeq.R
@@ -353,7 +353,7 @@ glmerApply <- function(geneList,
     newLCI <- exp(newY - newSE * 1.96)
     newUCI <- exp(newY + newSE * 1.96)
     predictdf <- c(exp(newY), newLCI, newUCI)
-    singular <- is.numeric(lme4::isSingular(fit))
+    singular <- as.numeric(lme4::isSingular(fit))
     conv <- length(slot(fit, "optinfo")$conv$lme4$messages)
     rm(fit, data)
     return(list(stats = c(stats, fixedEffects, waldtest),

--- a/R/glmmSeq.R
+++ b/R/glmmSeq.R
@@ -324,11 +324,11 @@ glmerApply <- function(geneList,
                        offset,
                        ...) {
   data[, "count"] <- as.numeric(geneList$y)
-  fit <- try(suppressWarnings(
+  fit <- try(suppressMessages(suppressWarnings(
     lme4::glmer(fullFormula, data = data, control = control, offset = offset,
                 family = MASS::negative.binomial(theta = 
                                                    1/geneList$dispersion)),
-    ...),
+    ...)),
     silent = TRUE)
   
   if (class(fit) != "try-error") {

--- a/R/glmmSeq.R
+++ b/R/glmmSeq.R
@@ -184,11 +184,7 @@ glmmSeq <- function(modelFormula,
     reducedVars <- rownames(attr(terms(reducedFormula), "factors"))
     varLevels <- lapply(reducedVars, function(x) {
       if (is.factor(metadata[, x])) {
-        if (is.ordered(metadata[, x])) {
-          return(paste0(x, c('.L', '.Q', '.C', '^4')))
-        } else {
-          return(levels(subsetMetadata[, x]))
-        }
+        return(levels(subsetMetadata[, x]))
       } else {sort(unique(subsetMetadata[, x]))}
     })
     modelData <- expand.grid(varLevels)

--- a/R/glmmSeq.R
+++ b/R/glmmSeq.R
@@ -183,8 +183,12 @@ glmmSeq <- function(modelFormula,
   if (is.null(modelData)) {
     reducedVars <- rownames(attr(terms(reducedFormula), "factors"))
     varLevels <- lapply(reducedVars, function(x) {
-      if (class(metadata[, x]) == "factor") {
-        return(levels(subsetMetadata[, x]))
+      if (is.factor(metadata[, x])) {
+        if (is.ordered(metadata[, x])) {
+          return(paste0(x, c('.L', '.Q', '.C', '^4')))
+        } else {
+          return(levels(subsetMetadata[, x]))
+        }
       } else {sort(unique(subsetMetadata[, x]))}
     })
     modelData <- expand.grid(varLevels)

--- a/R/glmmSeq.R
+++ b/R/glmmSeq.R
@@ -353,7 +353,7 @@ glmerApply <- function(geneList,
     newLCI <- exp(newY - newSE * 1.96)
     newUCI <- exp(newY + newSE * 1.96)
     predictdf <- c(exp(newY), newLCI, newUCI)
-    singular <- suppressMessages(is.numeric(lme4::isSingular(fit)))
+    singular <- is.numeric(lme4::isSingular(fit))
     conv <- length(slot(fit, "optinfo")$conv$lme4$messages)
     rm(fit, data)
     return(list(stats = c(stats, fixedEffects, waldtest),

--- a/R/glmmSeq.R
+++ b/R/glmmSeq.R
@@ -353,7 +353,7 @@ glmerApply <- function(geneList,
     newLCI <- exp(newY - newSE * 1.96)
     newUCI <- exp(newY + newSE * 1.96)
     predictdf <- c(exp(newY), newLCI, newUCI)
-    singular <- suppressWarnings(is.numeric(lme4::isSingular(fit)))
+    singular <- suppressMessages(is.numeric(lme4::isSingular(fit)))
     conv <- length(slot(fit, "optinfo")$conv$lme4$messages)
     rm(fit, data)
     return(list(stats = c(stats, fixedEffects, waldtest),

--- a/R/glmmSeq.R
+++ b/R/glmmSeq.R
@@ -42,6 +42,7 @@ setClass("GlmmSeq", slots = list(
 #'  \code{\link[lme4:glmer]{lme4::glmer()}}
 #' @param reducedFormula Reduced design formula (default = "")
 #' @param modelData Expanded design matrix
+#' @param designMatrix custom design matrix
 #' @param control the glmer control (default = glmerControl(optimizer = 
 #' "bobyqa")). For more information see
 #' \code{\link[lme4:glmerControl]{lme4::glmerControl()}}.
@@ -93,6 +94,7 @@ glmmSeq <- function(modelFormula,
                     sizeFactors = NULL,
                     reducedFormula = "",
                     modelData = NULL,
+                    designMatrix = NULL,
                     control = glmerControl(optimizer = "bobyqa"),
                     cores = 1,
                     removeDuplicatedMeasures = FALSE,
@@ -187,8 +189,11 @@ glmmSeq <- function(modelFormula,
     })
     modelData <- expand.grid(varLevels)
     colnames(modelData) <- reducedVars
-  }
-  designMatrix <- model.matrix(reducedFormula, modelData)
+  } 
+
+  if (is.null(designMatrix)){
+    designMatrix <- model.matrix(reducedFormula, modelData)
+  } 
   
   start <- Sys.time()
   fullList <- lapply(rownames(countdata), function(i) {

--- a/man/glmmSeq.Rd
+++ b/man/glmmSeq.Rd
@@ -13,6 +13,7 @@ glmmSeq(
   sizeFactors = NULL,
   reducedFormula = "",
   modelData = NULL,
+  designMatrix = NULL,
   control = glmerControl(optimizer = "bobyqa"),
   cores = 1,
   removeDuplicatedMeasures = FALSE,
@@ -44,6 +45,8 @@ offset is set to log(sizeFactors). For more information see
 \item{reducedFormula}{Reduced design formula (default = "")}
 
 \item{modelData}{Expanded design matrix}
+
+\item{designMatrix}{custom design matrix}
 
 \item{control}{the glmer control (default = glmerControl(optimizer =
 "bobyqa")). For more information see


### PR DESCRIPTION
Hi, thanks for this really great package!

I'm wanting to run a model that contains an ordered categorical factor (condition A > condition B > condition C) and made some adjustments to the code to allow a designMatrix option to basically overwrite the designMatrix to respect the way it would have been constructed if ordered factors were in the metadata; the columns would contain the levels of the ordered factor from 2 to 4 (.L, .Q, .C, ^4 instead of A,B,C). This is probably not the cleanest way to proceed but i think it sort of works. I'm not exactly sure how to compute the LFC from this but i can make do with the estimates for now. 

Best regards,
Kelvin